### PR TITLE
force metadata refresh

### DIFF
--- a/ctable/backends.py
+++ b/ctable/backends.py
@@ -58,6 +58,7 @@ class SqlBackend(CtableBackend):
 
     def __enter__(self):
         self.connection = self.base_connection.connect()  # "forks" the SqlAlchemy connection
+        self._metadata = None  # force metadata refresh
         self._op = None
         return self  # TODO: A safe context manager so this can be called many times
 


### PR DESCRIPTION
It would be fine without this if running in a single process but since we're running this from multiple workers we can't tell when something changed.

Future feature is to only reflect tables we're interested in instead of the whole db: http://docs.sqlalchemy.org/en/rel_0_7/core/schema.html#sqlalchemy.schema.MetaData.reflect
