### PR TITLE
use new urls module

### DIFF
--- a/ctable_view/urls.py
+++ b/ctable_view/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('ctable_view.views',
     url(r'^$', 'view', name='sql_mappings_list'),


### PR DESCRIPTION
django.conf.urls.defaults is deprecated and removed in Django 1.6